### PR TITLE
Quit subtitle when page change.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,7 @@
     ],
     "content_security_policy": "script-src 'self' 'wasm-eval'; object-src 'self'",
     "web_accessible_resources": ["worker_proxy.html"],
-    "permissions": [ "https://*.youtube.com/*" ],
+    "permissions": [ "https://*.youtube.com/*", "tabs"],
     "icons": {
         "16": "image/16.png",
         "32": "image/32.png",

--- a/src/popup.js
+++ b/src/popup.js
@@ -7,6 +7,18 @@ document.getElementById('load_sub_bt').addEventListener('click', function() {
     chrome.tabs.executeScript({
         code: 'var instance = new SubtitlesOctopus(options);'
     });
+
+    chrome.tabs.onUpdated.addListener(function
+        (tabId, changeInfo, tab) {
+          if (changeInfo.url) {
+
+              chrome.tabs.executeScript({
+                  code: 'instance.dispose();'
+              });
+              }
+        }
+    );
+
 });
 
 const input = document.getElementById('subtitle');


### PR DESCRIPTION
페이지 주소가 변경될 경우 instance.dispose()를 실행해 다른 페이지로 넘어가게 되면 ass파일이 로드되지 않도록 고쳤습니다.