### PR TITLE
#20 크롬 99버전에서 동작하지 않는현상 개선

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -41,6 +41,7 @@ async function loadSub(){
     if (subtitle_instance){
         subtitle_instance.freeTrack();
     }
+    options["video"] = document.getElementsByClassName('video-stream html5-main-video')[0]
     subtitle_instance = new SubtitlesOctopus(options);
 
     // ass 자막의 화면비율 측정하고 캔버스 크기 줄이기


### PR DESCRIPTION
- 로드 시에 video tag를 getelement 하도록 변경